### PR TITLE
Insert rules to use-color-change's own <style> element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,19 @@ import {useState, useEffect} from 'react';
 
 type ChangeableProperty = 'color' | 'background-color';
 
-const insertStyleSheetRule = (ruleText: string): void => {
-    const sheets = document.styleSheets;
+const USE_COLOR_CHANGE_ID = '__use_color_change';
 
-    if (sheets.length === 0) {
-        const style = document.createElement('style');
-        style.appendChild(document.createTextNode(''));
-        document.head.appendChild(style);
+const insertStyleSheetRule = (ruleText: string): void => {
+    let style = document.getElementById(USE_COLOR_CHANGE_ID) as HTMLStyleElement | null
+    if (style == null) {
+      style = document.createElement('style');
+      style.setAttribute('id', USE_COLOR_CHANGE_ID)
+      style.appendChild(document.createTextNode(''));
+      document.head.appendChild(style);
     }
 
-    const sheet = sheets[sheets.length - 1];
-    sheet.insertRule(
+    const { sheet } = style;
+    sheet?.insertRule(
         ruleText,
         sheet.rules ? sheet.rules.length : sheet.cssRules.length
     );


### PR DESCRIPTION
Since some add-ons and plugins inject <style>s of their own to the `document.head`, use-color-change tried to access the last added <style>'s rules of the `CSSStyleSheet` object, which might be problematic.

This might fail w/ a `DOMException`:

```
CSSStyleSheet.cssRules getter: Not allowed to access cross-origin style sheet
```

This can be observed for example on https://webkit.org/blog, opening the Web Console and accessing the rules:

```js
document.styleSheets[1].cssRules
```

This commit changes the logic of adding the rules to the target <style> element. First, check if there's a use-color-change specific <style> element already in the document's head. If so, use it to insert the CSS rules. Otherwise, create a new <style> element w/ a use-color-change identifier, add it to the document's head, and insert the CSS rules.
